### PR TITLE
Set up dev environment: fix in-browser Babel transpile + add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this repo actually is
+This repository is the **legacy production Expertia CRM app**: a single-file React SPA
+(`index.html`, ~1.2 MB) transpiled in-browser via Babel Standalone, wrapped by Electron
+(`main.js`) for desktop and served statically on the web. It talks directly to **real
+production Firebase** (project `expertiacrm-7e7eb`; config baked into `firebase-config.js`).
+
+Note: the root `CLAUDE.md` describes a *future* Next.js/Supabase rewrite. That rewrite does
+**not** exist in this repo — do not assume Next.js/Supabase/TanStack/etc. are present here.
+
+### How to run (dev)
+- Web (recommended in cloud): `node server.js` → serves `index.html` at http://localhost:3000.
+  There is no build step and no bundler; the browser compiles the inline `text/babel` script.
+- Desktop: `npm start` runs Electron — needs a display, so it is not suitable for headless runs.
+- First load takes ~30–60s: the "Cargando Expertia Business Suite…" screen stays up until Babel
+  finishes compiling the large inline script and React mounts. This is normal, not a hang.
+- External CDNs (unpkg, gstatic, cdnjs, tailwind) must be reachable; network egress is required.
+
+### Critical caveat: pin Babel Standalone to 7.x
+`index.html` loads `@babel/standalone`. It must stay pinned to a **Babel 7.x** version
+(currently `@7.28.0`). The unpinned/`latest` URL now resolves to Babel 8, whose `preset-react`
+defaults to the *automatic* JSX runtime and emits `import { jsx } from "react/jsx-runtime"` into
+the compiled output. Because that output is re-injected as a classic (non-module) `<script>`,
+the browser throws `Cannot use import statement outside a module` and the app is stuck forever on
+the loading screen. Babel 7.x keeps the classic runtime (`React.createElement`), which this app
+requires. Do not revert this pin to an unversioned URL.
+
+### Lint / tests / build
+- No lint or automated test setup exists (no ESLint, Vitest, Jest, or Playwright configured).
+  The many `test-*.js` / `debug-*.js` files are ad-hoc manual scripts, not a test suite.
+- "Build" here means Electron packaging (`npm run build` / `electron-builder`), not a web build.
+
+### Working against production Firebase (be careful)
+- Auth/Firestore writes hit the client's **live** database. Do **not** create, edit, or delete
+  real business records (clients, offers, invoices, etc.) during testing.
+- New sign-ups via "Crear cuenta ahora" create a real Firebase Auth user + `users/{uid}` doc.
+  A verified test account reaches the full CRM dashboard.
+- Per `CLAUDE.md`, store QA test credentials only in the git-ignored `.local/test-users.json`
+  (never commit passwords).

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://unpkg.com/@babel/standalone@7.28.0/babel.min.js"></script>
     <!-- PropTypes para Recharts -->
     <script src="https://unpkg.com/prop-types@15.8.1/prop-types.min.js"></script>
     <script src="./recharts.min.js"></script>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objetivo
Dejar el entorno de desarrollo listo para ejecutar y verificar la aplicación (la SPA legacy `index.html` + Firebase servida por `server.js`).

## Cambios
- **`index.html`**: se fija `@babel/standalone` a `7.28.0`. La URL sin versión ahora resuelve a **Babel 8**, cuyo `preset-react` usa por defecto el runtime JSX *automatic* e inyecta `import { jsx } from "react/jsx-runtime"` en el código compilado. Como ese código se reinyecta como script clásico (no módulo), el navegador lanza `Cannot use import statement outside a module` y la app se queda atascada en la pantalla de carga. Babel 7.x mantiene el runtime clásico (`React.createElement`) que la app necesita. Es un pin de dependencia, no un cambio de lógica.
- **`AGENTS.md`** (nuevo): notas de arranque/ejecución para futuros agentes (qué es realmente el repo vs. el `CLAUDE.md`, cómo ejecutar, el caveat del pin de Babel, ausencia de lint/tests, y el aviso de que se conecta a Firebase de producción real).

## Verificación
- `node server.js` → http://localhost:3000 responde HTTP 200.
- La app compila en el navegador, monta React y conecta a Firebase (`expertiacrm-7e7eb`).
- Hello-world (acción real contra el backend): registro de una cuenta de prueba (usuario creado en Firebase Auth + perfil en Firestore) y login que llega al **dashboard completo del CRM** con datos.
- No hay configuración de lint ni de tests automatizados en el repo.

### Evidencia
[expertia_crm_login_dashboard_demo.mp4](https://cursor.com/agents/bc-4a8aad12-abd0-4e4c-8339-a1b2fcb13fec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexpertia_crm_login_dashboard_demo.mp4)

[Pantalla de login](https://cursor.com/agents/bc-4a8aad12-abd0-4e4c-8339-a1b2fcb13fec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin_screen.webp)
[Dashboard del CRM cargado](https://cursor.com/agents/bc-4a8aad12-abd0-4e4c-8339-a1b2fcb13fec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_loaded.webp)

## Notas
- No se creó ni modificó ningún dato de negocio real en la base de datos de producción.
- Las credenciales de prueba QA se guardaron solo en `.local/test-users.json` (ignorado por git).
- Update script sugerido: `npm install`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a8aad12-abd0-4e4c-8339-a1b2fcb13fec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a8aad12-abd0-4e4c-8339-a1b2fcb13fec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

