### PR TITLE
fix: UX proforma/pago y script consulta support_logs

### DIFF
--- a/archive/tools/query-support-logs.mjs
+++ b/archive/tools/query-support-logs.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * Consulta support_logs en Firestore (requiere credenciales de admin).
+ *
+ * Uso:
+ *   export GOOGLE_APPLICATION_CREDENTIALS=/ruta/serviceAccountKey.json
+ *   node archive/tools/query-support-logs.mjs --name "Marta Rebaque"
+ *   node archive/tools/query-support-logs.mjs --user-index 5
+ *   node archive/tools/query-support-logs.mjs --uid <firebase-uid>
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { initializeApp, cert, applicationDefault } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+const PROJECT_ID = "expertiacrm-7e7eb";
+
+function parseArgs(argv) {
+  const args = { name: null, uid: null, userIndex: null, limit: 50 };
+  for (let i = 2; i < argv.length; i += 1) {
+    const key = argv[i];
+    const value = argv[i + 1];
+    if (key === "--name" && value) {
+      args.name = value;
+      i += 1;
+    } else if (key === "--uid" && value) {
+      args.uid = value;
+      i += 1;
+    } else if (key === "--user-index" && value) {
+      args.userIndex = Number(value);
+      i += 1;
+    } else if (key === "--limit" && value) {
+      args.limit = Number(value);
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function initAdmin() {
+  const localKey = new URL("./serviceAccountKey.json", import.meta.url);
+  if (existsSync(localKey)) {
+    const serviceAccount = JSON.parse(readFileSync(localKey, "utf8"));
+    initializeApp({
+      credential: cert(serviceAccount),
+      projectId: PROJECT_ID,
+    });
+    return;
+  }
+  initializeApp({
+    credential: applicationDefault(),
+    projectId: PROJECT_ID,
+  });
+}
+
+function formatTs(value) {
+  if (!value) return "—";
+  if (typeof value.toDate === "function") {
+    return value.toDate().toISOString();
+  }
+  return String(value);
+}
+
+async function resolveUserId(db, { name, uid, userIndex }) {
+  if (uid) return { id: uid, profile: null };
+
+  const usersSnap = await db.collection("users").get();
+  const users = usersSnap.docs
+    .map((doc) => ({ id: doc.id, ...doc.data() }))
+    .sort((a, b) => {
+      const aTs = a.createdAt || "";
+      const bTs = b.createdAt || "";
+      return String(aTs).localeCompare(String(bTs));
+    });
+
+  if (userIndex != null && Number.isFinite(userIndex)) {
+    const match = users[userIndex - 1];
+    if (!match) {
+      throw new Error(`No hay usuario en la posición #${userIndex} (total: ${users.length})`);
+    }
+    return { id: match.id, profile: match };
+  }
+
+  if (name) {
+    const normalized = name.trim().toLowerCase();
+    const match = users.find(
+      (user) => String(user.name || "").trim().toLowerCase() === normalized,
+    );
+    if (!match) {
+      const partial = users.filter((user) =>
+        String(user.name || "").toLowerCase().includes(normalized),
+      );
+      if (partial.length === 1) {
+        return { id: partial[0].id, profile: partial[0] };
+      }
+      throw new Error(
+        `No se encontró usuario con nombre "${name}". Coincidencias parciales: ${partial.map((u) => u.name).join(", ") || "ninguna"}`,
+      );
+    }
+    return { id: match.id, profile: match };
+  }
+
+  throw new Error("Indica --name, --uid o --user-index");
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  initAdmin();
+  const db = getFirestore();
+
+  const { id: userId, profile } = await resolveUserId(db, args);
+  console.log("Usuario resuelto:");
+  console.log(`  uid: ${userId}`);
+  if (profile) {
+    console.log(`  nombre: ${profile.name || "—"}`);
+    console.log(`  email: ${profile.email || "—"}`);
+    console.log(`  rol: ${profile.role || "—"}`);
+  }
+
+  const logsSnap = await db
+    .collection("support_logs")
+    .where("userId", "==", userId)
+    .limit(args.limit)
+    .get();
+
+  const logs = logsSnap.docs
+    .map((doc) => ({ id: doc.id, ...doc.data() }))
+    .sort((a, b) => String(b.createdAt || "").localeCompare(String(a.createdAt || "")));
+
+  console.log(`\nEventos support_logs (${logs.length}):`);
+  for (const log of logs) {
+    console.log("---");
+    console.log(`  id: ${log.id}`);
+    console.log(`  createdAt: ${formatTs(log.createdAt)}`);
+    console.log(`  level: ${log.level || "—"}`);
+    console.log(`  event: ${log.event || "—"}`);
+    if (log.context) console.log(`  context: ${JSON.stringify(log.context)}`);
+    if (log.error?.message) console.log(`  error: ${log.error.message}`);
+  }
+
+  const relevant = logs.filter((log) =>
+    /proforma|stock|invoice_payment|stock_apply/i.test(String(log.event || "")),
+  );
+  if (relevant.length > 0) {
+    console.log(`\nEventos relevantes (${relevant.length}):`);
+    for (const log of relevant) {
+      console.log(
+        `  [${formatTs(log.createdAt)}] ${log.level} ${log.event}${log.error?.message ? ` — ${log.error.message}` : ""}`,
+      );
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error("Error:", error.message || error);
+  process.exit(1);
+});

--- a/index.html
+++ b/index.html
@@ -1533,9 +1533,16 @@
               borderColor: "border-orange-200",
               progressColor: "bg-orange-500",
             },
+            error: {
+              icon: <XIcon width={24} height={24} />,
+              iconColor: "text-red-600",
+              bgColor: "bg-red-50",
+              borderColor: "border-red-200",
+              progressColor: "bg-red-500",
+            },
           };
 
-          const config = typeConfig[type] || typeConfig.success;
+          const config = typeConfig[type] || typeConfig.warning;
 
           if (!isOpen) return null;
 
@@ -4665,6 +4672,7 @@
             invoiceData,
             convertFromProforma = false,
           ) => {
+            let stockWarning = null;
             // Extraer campos solo-UI (no persistirlos en la factura)
             const {
               registerPaymentNow,
@@ -5132,15 +5140,24 @@
               const errDetail = String(error?.message || error || "").trim();
               const errShort =
                 errDetail.length > 180 ? `${errDetail.slice(0, 180)}…` : errDetail;
+              stockWarning = {
+                code: "stock_apply_failed",
+                detail: errShort || null,
+              };
               showNotification?.(
-                "Stock no actualizado",
+                convertFromProforma
+                  ? "Factura convertida — aviso de inventario"
+                  : "Factura guardada — aviso de inventario",
                 errShort
-                  ? `La factura se guardó, pero hubo un error actualizando el stock. Detalle: ${errShort}`
-                  : "La factura se guardó, pero hubo un error actualizando el stock.",
-                "error",
+                  ? `La factura y el pago se registraron correctamente. El inventario no se actualizó automáticamente (${errShort}). Si hace falta, un administrador puede reaplicar el stock.`
+                  : "La factura y el pago se registraron correctamente. El inventario no se actualizó automáticamente. Si hace falta, un administrador puede reaplicar el stock.",
+                "warning",
               );
             }
             setActiveView("accounting");
+            if (stockWarning) {
+              return { ok: true, stockWarning: true, warning: stockWarning };
+            }
             return true;
           };
 
@@ -5190,11 +5207,14 @@
                 method,
               },
             });
-            const ok = await handleSaveInvoice(invoiceData, true);
+            const result = await handleSaveInvoice(invoiceData, true);
+            const ok = result === true || result?.ok === true;
             window.logSupportEvent?.({
-              level: ok ? "info" : "error",
+              level: ok ? (result?.stockWarning ? "warning" : "info") : "error",
               event: ok
-                ? "proforma_convert_and_pay_success"
+                ? result?.stockWarning
+                  ? "proforma_convert_and_pay_success_stock_warning"
+                  : "proforma_convert_and_pay_success"
                 : "proforma_convert_and_pay_error",
               context: {
                 feature: "invoice_payment",
@@ -5206,9 +5226,10 @@
                 amount,
                 date: invoiceData.paymentNowDate,
                 method,
+                stockWarning: Boolean(result?.stockWarning),
               },
             });
-            return ok;
+            return result;
           };
 
           const handleSoftDeleteInvoice = async (invoiceId) => {
@@ -14465,6 +14486,15 @@ Fdo.: ${client.name || "[Firma del Cliente]"}`;
               if (ok) {
                 setPaymentAmount(0);
                 setPaymentModalOpen(false);
+                if (isProforma) {
+                  showNotification(
+                    "Factura convertida y pagada",
+                    result?.stockWarning
+                      ? "La proforma se convirtió en factura y el pago quedó registrado. Revisa el aviso de inventario si apareció."
+                      : "La proforma se convirtió en factura y el pago quedó registrado.",
+                    "success",
+                  );
+                }
               } else {
                 // Si no hay confirmación explícita, no cerramos para que el usuario pueda reintentar
                 showNotification(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumen

Corrige la experiencia de usuario al convertir/pagar proformas cuando falla la actualización de inventario (sin modificar la lógica de stock).

## Cambios

### UX (`index.html`)
- **`CustomNotification`**: añade tipo `error` (antes cualquier tipo desconocido mostraba icono verde de éxito).
- **Mensaje tras conversión/pago**: deja claro que la factura y el pago se completaron; el aviso de inventario es secundario y usa estilo `warning`.
- **Resultado de `handleSaveInvoice`**: devuelve `{ ok: true, stockWarning: true }` cuando el inventario falla, para que el modal de pago cierre correctamente sin parecer un error total.
- **Logging**: nuevo evento `proforma_convert_and_pay_success_stock_warning` cuando aplica.

### Herramienta de soporte
- Script `archive/tools/query-support-logs.mjs` para consultar `support_logs` por nombre, UID o posición de usuario (#5).

## Pendiente (requiere credenciales Firebase en local/CI)

1. Desplegar reglas: `firebase deploy --only firestore:rules --project expertiacrm-7e7eb`
2. Consultar logs de Marta Rebaque:
   ```bash
   export GOOGLE_APPLICATION_CREDENTIALS=/ruta/serviceAccountKey.json
   node archive/tools/query-support-logs.mjs --name "Marta Rebaque"
   # o
   node archive/tools/query-support-logs.mjs --user-index 5
   ```

## Notas

- No se ha modificado la lógica de descuento/reaplicación de stock.
- Este entorno cloud no dispone de `firebase login` ni service account para desplegar o leer Firestore.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7bb4dbe-84ad-47bd-a03f-7b4e1b1d8d27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7bb4dbe-84ad-47bd-a03f-7b4e1b1d8d27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

